### PR TITLE
Fix: MapController 변경

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -338,7 +338,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   mapPrefab: {fileID: 6260140572017040805, guid: 2dca6aa900aba493d9382063aa790ee7, type: 3}
   test: 0
-  testAnomaly: 2
+  testAnomaly: 1
 --- !u!4 &570821364
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Anomaly/Anomaly.cs
+++ b/Assets/Scripts/Anomaly/Anomaly.cs
@@ -1,6 +1,6 @@
 using UnityEngine;
 
-public abstract class Anomaly : MonoBehaviour
+public abstract class Anomaly
 {
     public abstract void Apply(GameObject myBedroom);
 }

--- a/Assets/Scripts/Anomaly/EasyLaptopAnomaly.cs
+++ b/Assets/Scripts/Anomaly/EasyLaptopAnomaly.cs
@@ -5,7 +5,7 @@ using UnityEngine;
 public class EasyLaptopAnomaly : Anomaly
 {
     public override void Apply(GameObject map) {
-        Laptop laptop = FindObjectOfType<Laptop>();
+        Laptop laptop = map.transform.Find("Bedroom").Find("laptop").GetComponent<Laptop>();
         laptop.inAnomaly = true;
     }
 }


### PR DESCRIPTION
이제 Anomaly 추가 때마다 MapController.Start()에 코드를 적어 넣을 필요 없음 + MonoBehaviour를 상속받지 않는 방식으로 변경