### PR TITLE
fix: github actions only when PR (not commits)

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,6 +1,5 @@
 name: Lint
 on: # yamllint disable-line rule:truthy
-  push: null
   pull_request: null
 permissions: {}
 jobs:

--- a/.github/workflows/unity-build.yml
+++ b/.github/workflows/unity-build.yml
@@ -1,6 +1,6 @@
 name: Unity Test
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
# Github action PR에만 실행하기
## Related Issue(s)
[Slack Message](https://2024fallswppimo.slack.com/archives/C07JD065SKF/p1732195693440649)
## PR Description
removed 'push' from on:
### Changes Included
- [ ] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation
### Notes for Reviewer
Check if the action is running on PR only.