### PR TITLE
Fix: 오븐에 시간 표시되어 있는 것 삭제

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -4318,7 +4318,7 @@ MonoBehaviour:
   easyAnomalyIndex: 0
   hardAnomalyIndex: 0
   test: 0
-  testAnomaly: 0
+  testAnomaly: 14
   testHard: 0
 --- !u!4 &896207470
 Transform:


### PR DESCRIPTION
# 오븐에 시간 표시되어 있는 것 삭제
## Related Issue(s)
None.
## PR Description
- 오븐에 12:43이라 시간 표시되어있어서 아예 Panel 위의 글씨 모두 삭제
### Changes Included
- [ ] Added new feature(s)
- [ ] Fixed identified bug(s)
- [ ] Updated relevant documentation
### Screenshots (if UI changes were made)
None.
### Notes for Reviewer
None.
---
## Reviewer Checklist
- [ ] Code is written in clean, maintainable, and idiomatic form.
- [ ] Automated test coverage is adequate.
- [ ] All existing tests pass.
- [ ] Manual testing has been performed to ensure the PR works as expected.
- [ ] Code review comments have been addressed or clarified.
---
## Additional Comments
None.